### PR TITLE
Fix JSONQuery not building on Unreal 4.24

### DIFF
--- a/JSONQuery.uplugin
+++ b/JSONQuery.uplugin
@@ -4,7 +4,7 @@
 	"FriendlyName" : "JSON Query",
 	"Version" : 8,
   "VersionName": "1.0.5",
-  "EngineVersion": "4.21.0",
+  "EngineVersion": "4.24.0",
 	"CreatedBy" : "Stefander",
 	"CreatedByURL" : "http://stefander.nl/",
 	"Description" : "Exposes nodes to Blueprint that allow you to easily post and request pages on webservers through the JSON protocol.",

--- a/Source/JSONQuery/Classes/JSONQueryModule.h
+++ b/Source/JSONQuery/Classes/JSONQueryModule.h
@@ -17,7 +17,7 @@
 */
 #pragma once
 
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 
 DECLARE_LOG_CATEGORY_CLASS(JSONQueryLog, Log, All);
 


### PR DESCRIPTION
It seems ModuleManager.h has moved to Modules/ModuleManager.h, as trying to build generates this error:

    Cannot open include file: 'ModuleManager.h': No such file or directory

https://docs.unrealengine.com/en-US/API/Runtime/Core/Modules/FModuleManager/index.html
